### PR TITLE
删除多余的划词分享功能

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -37,9 +37,6 @@
             share: [{
                 "bdSize": 16
             }],
-            selectShare: [{
-                "bdselectMiniList": ['qzone', 'tqq', 'kaixin001', 'bdxc', 'tqf']
-            }]
         };
         with (document) 0[(getElementsByTagName('head')[0] || body).appendChild(createElement('script')).src = 'http://bdimg.share.baidu.com/static/api/js/share.js?cdnversion=' + ~(-new Date() / 36e5)];
     </script>


### PR DESCRIPTION
用的百度提供的分享功能，当时复制的时候把划词分享也复制了过来，这个不仅没有用还会导致bug，现在删除